### PR TITLE
Fallback voor IP lookup naar HTTP_X_FORWARDED_FOR

### DIFF
--- a/user_sessions/middleware.py
+++ b/user_sessions/middleware.py
@@ -14,7 +14,7 @@ class SessionMiddleware(object):
         engine = import_module(settings.SESSION_ENGINE)
         session_key = request.COOKIES.get(settings.SESSION_COOKIE_NAME, None)
         request.session = engine.SessionStore(
-            ip=request.META.get('REMOTE_ADDR', ''),
+            ip=request.META.get('REMOTE_ADDR', request.META.get('HTTP_X_FORWARDED_FOR', '')),
             user_agent=request.META.get('HTTP_USER_AGENT', ''),
             session_key=session_key
         )


### PR DESCRIPTION
Fallback voor IP lookup naar HTTP_X_FORWARDED_FOR, om met gunicorn 19 om te kunnen gaan.
